### PR TITLE
[ 탁우현 ] 엔드포인트 추가 

### DIFF
--- a/src/controllers/confirmedQuoteController.ts
+++ b/src/controllers/confirmedQuoteController.ts
@@ -1,0 +1,26 @@
+import express from "express";
+import confirmedQuoteService from "../services/confirmedQuoteService";
+import { asyncHandle } from "../utils/asyncHandler";
+import passport from "../middlewares/passport";
+
+const router = express.Router();
+
+router.post(
+  "/:id",
+  passport.authenticate("jwt", { session: false }),
+  asyncHandle(async (req, res, next) => {
+    try {
+      const { customerId } = req.user as { customerId: number };
+      const { id } = req.params;
+      const confirmedQuote = await confirmedQuoteService.createConfirmedQuote({
+        quoteId: parseInt(id),
+        customerId,
+      });
+      res.status(201).json(confirmedQuote);
+    } catch (error) {
+      next(error);
+    }
+  })
+);
+
+export default router;

--- a/src/controllers/moverController.ts
+++ b/src/controllers/moverController.ts
@@ -105,14 +105,21 @@ router.post(
   })
 );
 
-//찜한 기사 조회
+//찜한 기사 목록 조회
 router.get(
   "/favorite-list",
   passport.authenticate("jwt", { session: false }),
   asyncHandle(async (req, res, next) => {
     try {
+      const { limit = "10", nextCursorId = "0" } = req.query;
+      const parseLimit = parseInt(limit as string);
+      const parseNextCursorId = parseInt(nextCursorId as string);
       const { customerId } = req.user as { customerId: number };
-      const movers = await moverService.getMoverByFavorite(customerId);
+      const movers = await moverService.getMoverByFavorite(
+        customerId,
+        parseLimit,
+        parseNextCursorId
+      );
       return res.status(200).send(movers);
     } catch (error) {
       next(error);

--- a/src/controllers/moverController.ts
+++ b/src/controllers/moverController.ts
@@ -105,4 +105,19 @@ router.post(
   })
 );
 
+//찜한 기사 조회
+router.get(
+  "/favorite-list",
+  passport.authenticate("jwt", { session: false }),
+  asyncHandle(async (req, res, next) => {
+    try {
+      const { customerId } = req.user as { customerId: number };
+      const movers = await moverService.getMoverByFavorite(customerId);
+      return res.status(200).send(movers);
+    } catch (error) {
+      next(error);
+    }
+  })
+);
+
 export default router;

--- a/src/repositorys/confirmedQuoteRepository.ts
+++ b/src/repositorys/confirmedQuoteRepository.ts
@@ -1,0 +1,58 @@
+import prismaClient from "../utils/prismaClient";
+
+interface ConfirmedQuote {
+  movingRequestId: number;
+  quoteId: number;
+  customerId: number;
+  moverId: number;
+}
+
+const CreateConfirmedQuote = (confirmedQuote: ConfirmedQuote) => {
+  return prismaClient.confirmedQuote.create({
+    data: confirmedQuote,
+    select: {
+      id: true,
+      movingRequest: {
+        select: {
+          id: true,
+          service: true,
+          movingDate: true,
+          pickupAddress: true,
+          dropOffAddress: true,
+        },
+      },
+      quote: {
+        select: {
+          id: true,
+          cost: true,
+          comment: true,
+        },
+      },
+      mover: {
+        select: {
+          id: true,
+          imageUrl: true,
+          services: true,
+          nickname: true,
+          career: true,
+          regions: true,
+          introduction: true,
+          _count: {
+            select: {
+              review: true,
+              favorite: true,
+              confirmedQuote: true,
+            },
+          },
+        },
+      },
+      customer: {
+        select: {
+          id: true,
+        },
+      },
+    },
+  });
+};
+
+export default { CreateConfirmedQuote };

--- a/src/repositorys/moverRepository.ts
+++ b/src/repositorys/moverRepository.ts
@@ -101,10 +101,27 @@ const toggleFavorite = async (moverId: number, favorite: object) => {
   });
 };
 
+const getMoverByFavorite = (customerId: number) => {
+  return prismaClient.mover.findMany({
+    orderBy: { createAt: "desc" },
+    take: 3,
+    where: { favorite: { some: { id: customerId } } },
+    select: {
+      ...defaultSelect,
+      favorite: {
+        select: {
+          id: true,
+        },
+      },
+    },
+  });
+};
+
 export default {
   getMoverCount,
   getMoverList,
   getRatingsByMoverIds,
   getMoverById,
   toggleFavorite,
+  getMoverByFavorite,
 };

--- a/src/repositorys/moverRepository.ts
+++ b/src/repositorys/moverRepository.ts
@@ -101,10 +101,16 @@ const toggleFavorite = async (moverId: number, favorite: object) => {
   });
 };
 
-const getMoverByFavorite = (customerId: number) => {
+const getMoverByFavorite = (
+  customerId: number,
+  limit: number,
+  cursor: number
+) => {
   return prismaClient.mover.findMany({
     orderBy: { createAt: "desc" },
-    take: 3,
+    take: limit + 1,
+    skip: cursor ? 1 : 0,
+    cursor: cursor ? { id: cursor } : undefined,
     where: { favorite: { some: { id: customerId } } },
     select: {
       ...defaultSelect,

--- a/src/services/confirmedQuoteService.ts
+++ b/src/services/confirmedQuoteService.ts
@@ -1,0 +1,53 @@
+import confirmedQuoteRepository from "../repositorys/confirmedQuoteRepository";
+import movingRequestRepository from "../repositorys/movingRequestRepository";
+import quoteRepository from "../repositorys/quoteRepository";
+import customError from "../utils/interfaces/customError";
+
+interface ConfirmedQuote {
+  quoteId: number;
+  customerId: number;
+}
+
+const createConfirmedQuote = async (confirmedQuoteData: ConfirmedQuote) => {
+  const activeMovingRequestPromise = movingRequestRepository.getActiveRequest(
+    confirmedQuoteData.customerId
+  );
+
+  const quotePromise = quoteRepository.getQuoteById(confirmedQuoteData.quoteId);
+
+  const [activeMovingRequest, quote] = await Promise.all([
+    activeMovingRequestPromise,
+    quotePromise,
+  ]);
+
+  if (!activeMovingRequest) {
+    const error: customError = new Error("Not Found");
+    error.status = 404;
+    error.data = {
+      message: "활동중인 이사요청이 없습니다.",
+    };
+    throw error;
+  }
+
+  if (!quote) {
+    const error: customError = new Error("Not Found");
+    error.status = 404;
+    error.data = {
+      message: "견적서를 찾을 수 없습니다.",
+    };
+    throw error;
+  }
+
+  const confirmedQuote = await confirmedQuoteRepository.CreateConfirmedQuote({
+    movingRequestId: activeMovingRequest.id,
+    quoteId: quote.id,
+    customerId: confirmedQuoteData.customerId,
+    moverId: quote.mover.id,
+  });
+
+  return confirmedQuote;
+};
+
+export default {
+  createConfirmedQuote,
+};

--- a/src/services/moverService.ts
+++ b/src/services/moverService.ts
@@ -113,9 +113,35 @@ const getMoverList = async (query: queryString, customerId: number | null) => {
 };
 
 //찜한 기사 목록 조회
-const getMoverByFavorite = async (customerId: number) => {
-  const movers = await moverRepository.getMoverByFavorite(customerId);
-  return movers;
+const getMoverByFavorite = async (
+  customerId: number,
+  limit: number,
+  cursor: number
+) => {
+  const movers = await moverRepository.getMoverByFavorite(
+    customerId,
+    limit,
+    cursor
+  );
+
+  const moverIds = movers.map((mover) => mover.id);
+  const ratingsByMover = await getRatingsByMoverIds(moverIds);
+  const processMovers = await processMoversData(
+    customerId,
+    movers,
+    ratingsByMover
+  );
+
+  //커서 설정
+  const nextMover = movers.length > limit;
+  const nextCursor = nextMover ? movers[limit - 1].id : "";
+  const hasNext = Boolean(nextCursor);
+
+  return {
+    nextCursor,
+    hasNext,
+    list: processMovers.slice(0, limit),
+  };
 };
 
 //기사 상세 조회

--- a/src/services/moverService.ts
+++ b/src/services/moverService.ts
@@ -112,6 +112,12 @@ const getMoverList = async (query: queryString, customerId: number | null) => {
   };
 };
 
+//찜한 기사 목록 조회
+const getMoverByFavorite = async (customerId: number) => {
+  const movers = await moverRepository.getMoverByFavorite(customerId);
+  return movers;
+};
+
 //기사 상세 조회
 const getMoverDetail = async (customerId: number | null, moverId: number) => {
   const mover = await moverRepository.getMoverById(customerId, moverId);
@@ -209,4 +215,5 @@ export default {
   getMoverList,
   getMoverDetail,
   toggleFavorite,
+  getMoverByFavorite,
 };


### PR DESCRIPTION
1. 견적서 확정하기

로그인한 사용자의 id로 활성중인 이사요청을 선택한 견적서의 id로 확정견적 테이블 레코드 생성

3. 찜한기사 목록조회

로그인한 사용자의 id와 favorite 관계가 있는 mover의 리스트를 조회 한다.
기사찾기의 3개와 리스트 조회의 활용을 위한 페이지 네이션추가   