### PR TITLE
[안재민] 알림 조회, 생성, 읽음 기능

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "bcrypt": "^5.1.1",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
+    "dayjs": "^1.11.13",
     "dompurify": "^3.2.2",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,7 @@ import session from "express-session";
 import cookieConfig from "./config/cookie.config";
 import customerRouter from "./controllers/customerController";
 import userRouter from "./controllers/userController";
+import notificationRouter from "./controllers/notificationController";
 
 const app = express();
 
@@ -66,6 +67,7 @@ app.use("/auth", authRouter);
 app.use("/oauth", oauthRouter);
 app.use("/customers", customerRouter);
 app.use("/users", userRouter);
+app.use("/notifications", notificationRouter);
 
 app.use(errorHandler); //전체 에러 핸들링 미들웨어
 

--- a/src/controllers/notificationController.ts
+++ b/src/controllers/notificationController.ts
@@ -14,7 +14,12 @@ router.get(
     try {
       const userId = (req.user as Payload).id;
       const query = {
-        isRead: req.query.isRead === "true",
+        isRead:
+          req.query.isRead === "true"
+            ? true
+            : req.query.isRead === "false"
+            ? false
+            : undefined,
         limit: parseInt(req.query.limit as string) || 10,
         lastCursorId: parseInt(req.query.lastCursorId as string) || undefined,
       };

--- a/src/controllers/notificationController.ts
+++ b/src/controllers/notificationController.ts
@@ -1,0 +1,49 @@
+import { Router } from "express";
+import notificationService from "../services/notificationService";
+import passport from "passport";
+import { asyncHandle } from "../utils/asyncHandler";
+import { Payload } from "../utils/token.utils";
+
+const router = Router();
+
+//알림 조회
+router.get(
+  "/",
+  passport.authenticate("jwt", { session: false }),
+  asyncHandle(async (req, res, next) => {
+    try {
+      const userId = (req.user as Payload).id;
+      const query = {
+        isRead: req.query.isRead === "true",
+        limit: parseInt(req.query.limit as string) || 10,
+        lastCursorId: parseInt(req.query.lastCursorId as string) || undefined,
+      };
+      const notifications = await notificationService.findNotifications(
+        userId,
+        query
+      );
+      res.status(200).json(notifications);
+    } catch (error) {
+      next(error);
+    }
+  })
+);
+
+//알림 읽음 처리
+router.post(
+  "/:id",
+  passport.authenticate("jwt", { session: false }),
+  asyncHandle(async (req, res, next) => {
+    try {
+      const notificationId = parseInt(req.params.id);
+      const notifications = await notificationService.isReadNotification(
+        notificationId
+      );
+      res.status(200).json(notifications);
+    } catch (error) {
+      next(error);
+    }
+  })
+);
+
+export default router;

--- a/src/controllers/notificationController.ts
+++ b/src/controllers/notificationController.ts
@@ -36,10 +36,8 @@ router.post(
   asyncHandle(async (req, res, next) => {
     try {
       const notificationId = parseInt(req.params.id);
-      const notifications = await notificationService.isReadNotification(
-        notificationId
-      );
-      res.status(200).json(notifications);
+      await notificationService.isReadNotification(notificationId);
+      res.status(204).send();
     } catch (error) {
       next(error);
     }

--- a/src/repositorys/notificationRepository.ts
+++ b/src/repositorys/notificationRepository.ts
@@ -1,0 +1,43 @@
+import prismaClient from "../utils/prismaClient";
+
+interface Notification {
+  isRead: boolean;
+  content: string;
+  userId: number;
+}
+
+interface Query {
+  isRead: boolean;
+  limit: number;
+  lastCursorId: number | undefined;
+}
+
+const findNotifications = async (userId: number, query: Query) => {
+  return await prismaClient.notification.findMany({
+    where: {
+      userId, //userId에 해당하는 알림
+      isRead: query.isRead,
+    },
+    take: query.limit,
+    ...(query.lastCursorId && { cursor: { id: query.lastCursorId } }),
+    skip: query.lastCursorId ? 1 : 0, //마지막 cursorId가 존재하면 1개 건너뛰기
+    orderBy: {
+      id: "desc",
+    },
+  });
+}; //userId에 해당하는 알림 중 읽지 않은 알림 찾기
+
+const createNotification = async (notification: Notification) => {
+  return await prismaClient.notification.create({
+    data: notification,
+  });
+};
+
+const isReadNotification = async (notificationId: number) => {
+  return await prismaClient.notification.update({
+    where: { id: notificationId },
+    data: { isRead: true },
+  });
+};
+
+export default { findNotifications, createNotification, isReadNotification };

--- a/src/repositorys/notificationRepository.ts
+++ b/src/repositorys/notificationRepository.ts
@@ -7,7 +7,7 @@ interface Notification {
 }
 
 interface Query {
-  isRead: boolean;
+  isRead: boolean | undefined;
   limit: number;
   lastCursorId: number | undefined;
 }
@@ -16,13 +16,13 @@ const findNotifications = async (userId: number, query: Query) => {
   return await prismaClient.notification.findMany({
     where: {
       userId, //userId에 해당하는 알림
-      isRead: query.isRead,
+      ...(query.isRead !== undefined && { isRead: query.isRead }), // isRead가 undefined면 둘다 조회
     },
     take: query.limit,
     ...(query.lastCursorId && { cursor: { id: query.lastCursorId } }),
     skip: query.lastCursorId ? 1 : 0, //마지막 cursorId가 존재하면 1개 건너뛰기
     orderBy: {
-      id: "desc",
+      createAt: "desc",
     },
   });
 }; //userId에 해당하는 알림 중 읽지 않은 알림 찾기

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -16,7 +16,23 @@ interface Query {
 }
 
 dayjs.extend(relativeTime); //dayjs에 relativeTime 플러그인 추가
-dayjs.locale("ko"); //dayjs에 한국어 설정
+dayjs.locale("ko", {
+  relativeTime: {
+    future: "%s 후",
+    past: "%s 전",
+    s: "몇 초",
+    m: "1분",
+    mm: "%d분",
+    h: "1시간",
+    hh: "%d시간",
+    d: "1일",
+    dd: "%d일",
+    M: "1개월",
+    MM: "%d개월",
+    y: "1년",
+    yy: "%d년",
+  },
+}); //dayjs에 한국어 설정 (2번째 인자는 1의 경우 한국어로 기본설정되어 "하루 전"으로 표시되는 것을 숫자로 표현하게 함)
 
 const calculateTimeGap = (createAt: Date | string): string => {
   return dayjs(createAt).fromNow();

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -1,0 +1,60 @@
+import dayjs from "dayjs";
+import notificationRepository from "../repositorys/notificationRepository";
+import relativeTime from "dayjs/plugin/relativeTime";
+import "dayjs/locale/ko";
+
+interface Notification {
+  isRead: boolean;
+  content: string;
+  userId: number;
+}
+
+interface Query {
+  isRead: boolean;
+  limit: number;
+  lastCursorId: number | undefined;
+}
+
+dayjs.extend(relativeTime); //dayjs에 relativeTime 플러그인 추가
+dayjs.locale("ko"); //dayjs에 한국어 설정
+
+const calculateTimeGap = (createAt: Date | string): string => {
+  return dayjs(createAt).fromNow();
+}; //알림 생성 시간 계산
+
+const findNotifications = async (userId: number, query: Query) => {
+  const notifications = await notificationRepository.findNotifications(
+    userId,
+    query
+  );
+
+  const hasNext = notifications.length === query.limit; //다음 페이지 존재여부 확인
+
+  const addTimeGap = notifications.map((notification) => ({
+    ...notification,
+    timeGap: calculateTimeGap(notification.createAt),
+  })); //각 알림에 timeGap 추가
+
+  return {
+    notifications: addTimeGap,
+    hasNext,
+    lastCursorId:
+      notifications.length > 0
+        ? notifications[notifications.length - 1].id
+        : null, //마지막 알림의 id
+  };
+};
+
+const createNotification = async (notification: Notification) => {
+  return await notificationRepository.createNotification(notification);
+};
+
+const isReadNotification = async (notificationId: number) => {
+  return await notificationRepository.isReadNotification(notificationId);
+};
+
+export default {
+  findNotifications,
+  createNotification,
+  isReadNotification,
+};

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -10,7 +10,7 @@ interface Notification {
 }
 
 interface Query {
-  isRead: boolean;
+  isRead: boolean | undefined;
   limit: number;
   lastCursorId: number | undefined;
 }


### PR DESCRIPTION
## 1. 알림 조회
- 라이브러리 추가 : dayjs (매우 가벼운 시간관련 라이브러리)
- 읽음(true), 읽지않음(false), 모두(undifined) / 3가지 가져오도록 설정 (노션 프론트 요청사항)
#### 1-1. 프론트 요청사항(노션)
- nextCursor
    - 내용 : 다음 기사 아이디(cursor 방식 사용)
    - 용도 : 다음 기사 목록 조회 API에 사용
- hasNext
    - 내용 : 남은 기사 목록 유무
    - 용도 : 기사 목록 조회 API 조건에 사용
- list
    - 내용 : **알림 목록** 배열
    - 용도 : 화면 출력
```
{
	"nextCursor": 12, // hasNext 만약 없어도 nextCursor가 null이면 
	"hasNext": true,
	"list" : [
		{ 
			"id" : 1 , 
			"content" : "김사과 기사님의 소형이사 견적이 도착했어요",
			"isRead" : false,
			"timeGap" : "0000-00-00T01:30:00.000Z"
		},
		...
	]
}
```
#### 1-2. 문제
- 다음 기사 아이디를 전달할 경우 로직의 복잡성 증가
*서비스에서 다음 기사 아이디를 위해 limit에 +1추가하고 데이터 찾은 뒤 다음 기사 데이터 삭제 로직 추가
*skip 사용 일부 제한
이러한 문제로 아래 사진과 같이 lastCursorId로 마지막 데이터 id를 전달하도록 설정 => 코드 간결해짐
![image](https://github.com/user-attachments/assets/62ea3c53-95ec-44e8-bb69-16727e84d4d4)

## 2. 알림 생성
컨트롤러, 레포지토리 구성 / 컨트롤러 임시로 만들어서 생성 테스트 완료

## 3. 알림 읽음 처리

## 4. 기타사항
- 알림기능 프론트 요구사항에 최대한 맞게 작성하였습니다.
- 나름대로 주석 작성하였는데 이해 안가시는부분 말씀부탁드립니다.