### PR TITLE
[안재민] 회원가입(고객,기사), 유저수정 패스워드 해싱 / 컨트롤러 이미지 처리 추가, 이메일과 전화번호 중복조회 api추가

### DIFF
--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -122,6 +122,19 @@ router.post(
 );
 
 router.post(
+  "/validate",
+  asyncHandle(async (req, res, next) => {
+    try {
+      const { email, phoneNumber } = req.body;
+      await authService.validate(email, phoneNumber);
+      res.status(204).send();
+    } catch (error) {
+      next(error);
+    }
+  })
+);
+
+router.post(
   "/refresh",
   passport.authenticate("refresh-token", { session: false }),
   asyncHandle(async (req, res, next) => {

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -2,8 +2,9 @@ import { Router } from "express";
 import authService from "../services/authService";
 import { asyncHandle } from "../utils/asyncHandler";
 import cookieConfig from "../config/cookie.config";
-import createToken from "../utils/token.utils";
+import createToken, { Payload } from "../utils/token.utils";
 import upload from "../utils/multer";
+import passport from "passport";
 
 const router = Router();
 
@@ -75,18 +76,19 @@ router.post(
   upload.single("imageUrl"),
   asyncHandle(async (req, res, next) => {
     try {
-      const SignUpCustomer: SignUpCustomer = {
+      const signUpCustomer: SignUpCustomer = {
         ...req.body,
         imageUrl: req.file!,
         services: Array.isArray(req.body.services)
-          ? req.body.services
-          : JSON.parse(req.body.services),
+          ? req.body.services.map(Number)
+          : JSON.parse(req.body.services).map(Number),
         regions: Array.isArray(req.body.regions)
-          ? req.body.regions
-          : JSON.parse(req.body.regions),
+          ? req.body.regions.map(Number)
+          : JSON.parse(req.body.regions).map(Number),
         isOAuth: req.body.isOAuth === "true",
       };
-      await authService.signUpCustomer(SignUpCustomer);
+
+      await authService.signUpCustomer(signUpCustomer);
       res.status(204).send();
     } catch (error) {
       next(error);
@@ -99,8 +101,34 @@ router.post(
   upload.single("imageUrl"),
   asyncHandle(async (req, res, next) => {
     try {
-      const SignUpMover: SignUpMover = req.body;
+      const SignUpMover: SignUpMover = {
+        ...req.body,
+        imageUrl: req.file!,
+        services: Array.isArray(req.body.services)
+          ? req.body.services.map(Number)
+          : JSON.parse(req.body.services).map(Number),
+        regions: Array.isArray(req.body.regions)
+          ? req.body.regions.map(Number)
+          : JSON.parse(req.body.regions).map(Number),
+        isOAuth: req.body.isOAuth === "true",
+        career: Number(req.body.career),
+      };
       await authService.signUpMover(SignUpMover);
+      res.status(204).send();
+    } catch (error) {
+      next(error);
+    }
+  })
+);
+
+router.post(
+  "/refresh",
+  passport.authenticate("refresh-token", { session: false }),
+  asyncHandle(async (req, res, next) => {
+    try {
+      const user = req.user as Payload;
+      const accessToken = createToken(user, "access");
+      res.cookie("accessToken", accessToken, cookieConfig.accessTokenOption);
       res.status(204).send();
     } catch (error) {
       next(error);

--- a/src/controllers/customerController.ts
+++ b/src/controllers/customerController.ts
@@ -17,12 +17,16 @@ router.post(
       const profile = {
         userId: userId,
         imageUrl: req.file!,
-        services: Array.isArray(req.body.services)
-          ? req.body.services
-          : JSON.parse(req.body.services),
-        regions: Array.isArray(req.body.regions)
-          ? req.body.regions
-          : JSON.parse(req.body.regions), //postman으로 테스트하였는데 문자 배열로 인식하는 것 같아 임시 코드 작성 수정예정
+        regions: req.body.regions
+          ? Array.isArray(req.body.regions)
+            ? req.body.regions.map(Number)
+            : JSON.parse(req.body.regions).map(Number)
+          : [],
+        services: req.body.services
+          ? Array.isArray(req.body.services)
+            ? req.body.services.map(Number)
+            : JSON.parse(req.body.services).map(Number)
+          : [],
       };
       await customerService.createCustomerProfile(profile);
       res.status(204).send();
@@ -39,7 +43,16 @@ router.patch(
   asyncHandle(async (req, res, next) => {
     try {
       const userId = (req.user as Payload).id;
-      const profile = { ...req.body, imageUrl: req.file };
+      const profile = {
+        ...req.body,
+        imageUrl: req.file,
+        regions: req.body.regions
+          ? JSON.parse(req.body.regions).map(Number)
+          : [],
+        services: req.body.services
+          ? JSON.parse(req.body.services).map(Number)
+          : [],
+      };
       await customerService.updateCustomerProfile(userId, profile);
       res.status(204).send();
     } catch (error) {

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -44,9 +44,7 @@ const signIn = async ({ email, password }: SignInData) => {
     throw error;
   }
 
-  // const isPasswordValid = await bcrypt.compare(password, user.password!);
-
-  const isPasswordValid = password === user.password;
+  const isPasswordValid = await bcrypt.compare(password, user.password!); //패스워드 검증
 
   if (!isPasswordValid) {
     const error: CustomError = new Error("Unauthorized");
@@ -87,9 +85,12 @@ const signUpCustomer = async (customer: SignUpCustomer) => {
       }
     }
 
+    const hashedPassword = await bcrypt.hash(customer.password, 10);
+
     const customerData = {
       ...customer,
       imageUrl,
+      password: hashedPassword,
     };
 
     const result = await userRepository.createCustomer(customerData);
@@ -125,9 +126,12 @@ const signUpMover = async (mover: SignUpMover) => {
       }
     }
 
+    const hashedPassword = await bcrypt.hash(mover.password, 10);
+
     const moverData = {
       ...mover,
       imageUrl,
+      password: hashedPassword,
     };
     const result = await userRepository.createMover(moverData);
 

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -141,4 +141,28 @@ const signUpMover = async (mover: SignUpMover) => {
   }
 };
 
-export default { signIn, signUpCustomer, signUpMover };
+const validate = async (email: string, phoneNumber: string) => {
+  const user = await userRepository.existingUser(email, phoneNumber);
+
+  if (user) {
+    const error: CustomError = new Error("Conflict");
+    if (user.email === email) {
+      error.status = 409;
+      error.data = {
+        message: "이미 존재하는 이메일입니다.",
+      };
+      throw error;
+    }
+    if (user.phoneNumber === phoneNumber) {
+      error.status = 409;
+      error.data = {
+        message: "이미 존재하는 전화번호입니다.",
+      };
+      throw error;
+    }
+  }
+
+  return user;
+};
+
+export default { signIn, signUpCustomer, signUpMover, validate };


### PR DESCRIPTION
1. 회원가입(고객,기사)
2. 유저수정

패스워드 해싱 코드 추가입니다.

처음부터 시드데이터 비밀번호 여쭤볼걸 그랬습니다..ㅠ 빼먹고있었습니다