### PR TITLE
[안재민-fix] 기사 프로필 변경 추가, 유저 정보 변경 시 비밀번호 해시 조건 추가, 리프레시 토큰 path 적용

### DIFF
--- a/src/config/cookie.config.ts
+++ b/src/config/cookie.config.ts
@@ -5,7 +5,7 @@ const accessTokenOption: CookieOptions = {
   secure: true,
   sameSite: "none",
   maxAge: 1000 * 60 * 60, // 1시간
-  // path: "/",
+  path: "/",
 };
 
 const refreshTokenOption: CookieOptions = {
@@ -13,14 +13,15 @@ const refreshTokenOption: CookieOptions = {
   secure: true,
   sameSite: "none",
   maxAge: 1000 * 60 * 60 * 24 * 7, // 7일
-  // path: "/auth/refresh",
+  path: "/auth/refresh",
 };
 
 const clearCookieOption: CookieOptions = {
   httpOnly: true,
-  secure: false,
-  sameSite: "lax",
+  secure: true,
+  sameSite: "none",
   maxAge: 0,
+  path: "/",
 };
 
 const sessionOption: CookieOptions = {

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -149,4 +149,19 @@ router.post(
   })
 );
 
+router.post(
+  "/password",
+  passport.authenticate("jwt", { session: false }),
+  asyncHandle(async (req, res, next) => {
+    try {
+      const userId = (req.user as Payload).id;
+      const { password } = req.body;
+      await authService.validatePassword(userId, password);
+      res.status(204).send();
+    } catch (error) {
+      next(error);
+    }
+  })
+);
+
 export default router;

--- a/src/controllers/customerController.ts
+++ b/src/controllers/customerController.ts
@@ -43,6 +43,7 @@ router.patch(
   asyncHandle(async (req, res, next) => {
     try {
       const userId = (req.user as Payload).id;
+      const customerId = (req.user as { customerId: number }).customerId;
       const profile = {
         ...req.body,
         imageUrl: req.file,
@@ -53,7 +54,7 @@ router.patch(
           ? JSON.parse(req.body.services).map(Number)
           : [],
       };
-      await customerService.updateCustomerProfile(userId, profile);
+      await customerService.updateCustomerProfile(userId, customerId, profile);
       res.status(204).send();
     } catch (error) {
       next(error);

--- a/src/controllers/moverController.ts
+++ b/src/controllers/moverController.ts
@@ -169,4 +169,35 @@ router.patch(
   })
 );
 
+router.post(
+  "/",
+  passport.authenticate("jwt", { session: false }),
+  upload.single("imageUrl"),
+  asyncHandle(async (req, res, next) => {
+    try {
+      const userId = (req.user as Payload).id;
+      const profile = {
+        userId: userId,
+        ...req.body,
+        career: parseInt(req.body.career),
+        imageUrl: req.file!,
+        regions: req.body.regions
+          ? Array.isArray(req.body.regions)
+            ? req.body.regions.map(Number)
+            : JSON.parse(req.body.regions).map(Number)
+          : [],
+        services: req.body.services
+          ? Array.isArray(req.body.services)
+            ? req.body.services.map(Number)
+            : JSON.parse(req.body.services).map(Number)
+          : [],
+      };
+      await moverService.createMoverProfile(profile);
+      res.status(204).send();
+    } catch (error) {
+      next(error);
+    }
+  })
+);
+
 export default router;

--- a/src/controllers/moverController.ts
+++ b/src/controllers/moverController.ts
@@ -151,9 +151,11 @@ router.patch(
   asyncHandle(async (req, res, next) => {
     try {
       const userId = (req.user as Payload).id;
+      const moverId = (req.user as { moverId: number }).moverId;
       const profile = {
         ...req.body,
         imageUrl: req.file,
+        career: parseInt(req.body.career),
         regions: req.body.regions
           ? JSON.parse(req.body.regions).map(Number)
           : [],
@@ -161,7 +163,7 @@ router.patch(
           ? JSON.parse(req.body.services).map(Number)
           : [],
       };
-      await moverService.updateMoverProfile(userId, profile);
+      await moverService.updateMoverProfile(userId, moverId, profile);
       res.status(204).send();
     } catch (error) {
       next(error);

--- a/src/controllers/moverController.ts
+++ b/src/controllers/moverController.ts
@@ -4,6 +4,8 @@ import express from "express";
 import checkBoolean from "../utils/checkBoolean";
 import passport from "passport";
 import { optionalJwtAuth } from "../middlewares/authMiddleware";
+import upload from "../utils/multer";
+import { Payload } from "../utils/token.utils";
 
 interface queryString {
   nextCursorId: string;
@@ -136,6 +138,31 @@ router.get(
       const { moverId } = req.user as { moverId: number };
       const mover = await moverService.getMover(moverId);
       res.status(200).send(mover);
+    } catch (error) {
+      next(error);
+    }
+  })
+);
+
+router.patch(
+  "/",
+  passport.authenticate("jwt", { session: false }),
+  upload.single("imageUrl"),
+  asyncHandle(async (req, res, next) => {
+    try {
+      const userId = (req.user as Payload).id;
+      const profile = {
+        ...req.body,
+        imageUrl: req.file,
+        regions: req.body.regions
+          ? JSON.parse(req.body.regions).map(Number)
+          : [],
+        services: req.body.services
+          ? JSON.parse(req.body.services).map(Number)
+          : [],
+      };
+      await moverService.updateMoverProfile(userId, profile);
+      res.status(204).send();
     } catch (error) {
       next(error);
     }

--- a/src/repositorys/imageRepository.ts
+++ b/src/repositorys/imageRepository.ts
@@ -1,26 +1,18 @@
 import prismaClient from "../utils/prismaClient";
 
-const createImage = async (customerId: number, imageUrl: string) => {
-  return prismaClient.profileImage.create({
-    data: {
-      imageUrl,
-      customerId,
-      status: true,
-    },
-  }); //새로운 이미지 활성화
-};
+interface UpdateMoverProfile {
+  nickname?: string;
+  career?: number;
+  introduction?: string;
+  description?: string;
+  services?: number[];
+  regions?: number[];
+}
 
-const deactivateImage = async (customerId: number) => {
-  return prismaClient.profileImage.updateMany({
-    where: {
-      customerId,
-      status: true,
-    },
-    data: {
-      status: false,
-    },
-  });
-}; //기존 이미지 비활성화
+interface UpdateCustomerProfile {
+  services?: number[];
+  regions?: number[];
+}
 
 const findInActiveImage = async () => {
   return prismaClient.profileImage.findMany({
@@ -38,4 +30,85 @@ const deleteImage = async (imageUrl: string) => {
   });
 };
 
-export default { createImage, deactivateImage, deleteImage, findInActiveImage };
+const updateMoverProfile = async (
+  imageUrl: string | undefined,
+  userId: number,
+  moverId: number,
+  profile: UpdateMoverProfile
+) => {
+  //이미지url 여부에 따라 조건부 트랜잭션 생성
+  const imageTransactions = imageUrl
+    ? [
+        prismaClient.profileImage.updateMany({
+          where: {
+            moverId,
+            status: true,
+          },
+          data: {
+            status: false,
+          },
+        }),
+        prismaClient.profileImage.create({
+          data: {
+            imageUrl,
+            moverId,
+            status: true,
+          },
+        }),
+      ]
+    : [];
+
+  const profileTransaction = prismaClient.mover.update({
+    where: { userId: userId },
+    data: profile,
+  });
+
+  const transactions = [...imageTransactions, profileTransaction];
+
+  return prismaClient.$transaction(transactions);
+};
+
+const updateCustomerProfile = async (
+  imageUrl: string | undefined,
+  userId: number,
+  customerId: number,
+  profile: UpdateCustomerProfile
+) => {
+  //이미지url 여부에 따라 조건부 트랜잭션 생성
+  const imageTransactions = imageUrl
+    ? [
+        prismaClient.profileImage.updateMany({
+          where: {
+            customerId,
+            status: true,
+          },
+          data: {
+            status: false,
+          },
+        }),
+        prismaClient.profileImage.create({
+          data: {
+            imageUrl,
+            customerId,
+            status: true,
+          },
+        }),
+      ]
+    : [];
+
+  const profileTransaction = prismaClient.customer.update({
+    where: { userId: userId },
+    data: profile,
+  });
+
+  const transactions = [...imageTransactions, profileTransaction];
+
+  return prismaClient.$transaction(transactions);
+};
+
+export default {
+  updateMoverProfile,
+  deleteImage,
+  findInActiveImage,
+  updateCustomerProfile,
+};

--- a/src/repositorys/moverRepository.ts
+++ b/src/repositorys/moverRepository.ts
@@ -16,6 +16,17 @@ interface UpdateProfile {
   regions?: number[];
 }
 
+interface Profile {
+  userId: number;
+  nickname: string;
+  career: number;
+  introduction: string;
+  description: string;
+  services: number[];
+  regions: number[];
+  imageUrl: string;
+}
+
 const defaultSelect = {
   id: true,
   services: true,
@@ -187,6 +198,12 @@ const updateMoverProfile = async (userId: number, profile: UpdateProfile) => {
   });
 };
 
+const createMoverProfile = (profile: Profile) => {
+  return prismaClient.mover.create({
+    data: { ...profile, imageUrl: { create: { imageUrl: profile.imageUrl } } },
+  });
+};
+
 export default {
   getMoverCount,
   getMoverList,
@@ -195,4 +212,5 @@ export default {
   toggleFavorite,
   getMoverByFavorite,
   updateMoverProfile,
+  createMoverProfile,
 };

--- a/src/repositorys/moverRepository.ts
+++ b/src/repositorys/moverRepository.ts
@@ -191,13 +191,6 @@ const getMoverByFavorite = (
   });
 };
 
-const updateMoverProfile = async (userId: number, profile: UpdateProfile) => {
-  return prismaClient.mover.update({
-    where: { userId: userId },
-    data: profile,
-  });
-};
-
 const createMoverProfile = (profile: Profile) => {
   return prismaClient.mover.create({
     data: { ...profile, imageUrl: { create: { imageUrl: profile.imageUrl } } },
@@ -211,6 +204,5 @@ export default {
   getMoverById,
   toggleFavorite,
   getMoverByFavorite,
-  updateMoverProfile,
   createMoverProfile,
 };

--- a/src/repositorys/moverRepository.ts
+++ b/src/repositorys/moverRepository.ts
@@ -7,6 +7,15 @@ interface whereConditions {
   OR?: object[];
 }
 
+interface UpdateProfile {
+  nickname?: string;
+  career?: number;
+  introduction?: string;
+  description?: string;
+  services?: number[];
+  regions?: number[];
+}
+
 const defaultSelect = {
   id: true,
   services: true,
@@ -171,6 +180,13 @@ const getMoverByFavorite = (
   });
 };
 
+const updateMoverProfile = async (userId: number, profile: UpdateProfile) => {
+  return prismaClient.mover.update({
+    where: { userId: userId },
+    data: profile,
+  });
+};
+
 export default {
   getMoverCount,
   getMoverList,
@@ -178,4 +194,5 @@ export default {
   getMoverById,
   toggleFavorite,
   getMoverByFavorite,
+  updateMoverProfile,
 };

--- a/src/repositorys/userRepository.ts
+++ b/src/repositorys/userRepository.ts
@@ -243,6 +243,13 @@ const updateUser = async (userId: number, data: UpdateUser) => {
   });
 };
 
+const findPassword = (userId: number) => {
+  return prismaClient.user.findUnique({
+    where: { id: userId },
+    select: { password: true },
+  });
+};
+
 export default {
   findByEmail,
   createCustomer,
@@ -254,4 +261,5 @@ export default {
   getMover,
   updateUser,
   findById,
+  findPassword,
 };

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -165,4 +165,35 @@ const validate = async (email: string, phoneNumber: string) => {
   return user;
 };
 
-export default { signIn, signUpCustomer, signUpMover, validate };
+const validatePassword = async (userId: number, password: string) => {
+  const findPassword = await userRepository.findPassword(userId);
+  const decodedPassword = await bcrypt.compare(
+    password,
+    findPassword?.password!
+  );
+  if (!findPassword) {
+    const error: CustomError = new Error("Not Found");
+    error.status = 404;
+    error.data = {
+      message: "사용자가 존재하지 않습니다.",
+    };
+    throw error;
+  }
+
+  if (!decodedPassword) {
+    const error: CustomError = new Error("Unauthorized");
+    error.status = 401;
+    error.data = {
+      message: "비밀번호가 일치하지 않습니다.",
+    };
+    throw error;
+  }
+};
+
+export default {
+  signIn,
+  signUpCustomer,
+  signUpMover,
+  validate,
+  validatePassword,
+};

--- a/src/services/customerService.ts
+++ b/src/services/customerService.ts
@@ -34,27 +34,33 @@ const updateCustomerProfile = async (
   profile: UpdateProfile
 ) => {
   const { imageUrl, ...rest } = profile;
+  let uploadedImageUrl;
+
+  if (imageUrl) {
+    try {
+      uploadedImageUrl = await uploadFile(imageUrl);
+    } catch (e) {
+      const error: CustomError = new Error("Internal Server Error");
+      error.status = 500;
+      error.data = {
+        message: "이미지 업로드 실패",
+      };
+      throw error;
+    }
+  }
 
   try {
-    let uploadedImageUrl;
-    if (imageUrl) {
-      uploadedImageUrl = await uploadFile(imageUrl);
-    }
-
-    const result = await imageRepository.updateCustomerProfile(
+    return await imageRepository.updateCustomerProfile(
       uploadedImageUrl,
       userId,
       customerId,
-      {
-        ...rest,
-      }
+      rest
     );
-    return result;
   } catch (e) {
     const error: CustomError = new Error("Internal Server Error");
     error.status = 500;
     error.data = {
-      message: "이미지 업로드 실패",
+      message: "프로필 업데이트 실패",
     };
     throw error;
   }

--- a/src/services/moverService.ts
+++ b/src/services/moverService.ts
@@ -284,27 +284,33 @@ const updateMoverProfile = async (
   profile: UpdateProfile
 ) => {
   const { imageUrl, ...rest } = profile;
+  let uploadedImageUrl;
+
+  if (imageUrl) {
+    try {
+      uploadedImageUrl = await uploadFile(imageUrl);
+    } catch (e) {
+      const error: CustomError = new Error("Internal Server Error");
+      error.status = 500;
+      error.data = {
+        message: "이미지 업로드 실패",
+      };
+      throw error;
+    }
+  }
 
   try {
-    let uploadedImageUrl;
-    if (imageUrl) {
-      uploadedImageUrl = await uploadFile(imageUrl);
-    }
-
-    const result = await imageRepository.updateMoverProfile(
+    return await imageRepository.updateMoverProfile(
       uploadedImageUrl,
       userId,
       moverId,
-      {
-        ...rest,
-      }
+      rest
     );
-    return result;
   } catch (e) {
     const error: CustomError = new Error("Internal Server Error");
     error.status = 500;
     error.data = {
-      message: "이미지 업로드 실패",
+      message: "프로필 업데이트 실패",
     };
     throw error;
   }

--- a/src/services/moverService.ts
+++ b/src/services/moverService.ts
@@ -40,6 +40,17 @@ interface UpdateProfile {
   regions?: number[];
 }
 
+interface Profile {
+  userId: number;
+  nickname: string;
+  career: number;
+  introduction: string;
+  description: string;
+  services: number[];
+  regions: number[];
+  imageUrl: Express.Multer.File;
+}
+
 const setOrderByOptions = (
   order: string
 ): { [key: string]: object | string } => {
@@ -285,6 +296,15 @@ const updateMoverProfile = async (userId: number, profile: UpdateProfile) => {
   });
 };
 
+const createMoverProfile = async (profile: Profile) => {
+  const imageUrl = await uploadFile(profile.imageUrl);
+  const moverProfile = {
+    ...profile,
+    imageUrl,
+  };
+  return moverRepository.createMoverProfile(moverProfile);
+};
+
 export default {
   getMoverList,
   getMoverDetail,
@@ -292,4 +312,5 @@ export default {
   getMoverByFavorite,
   getMover,
   updateMoverProfile,
+  createMoverProfile,
 };

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -33,12 +33,23 @@ interface MoverResponse {
 
 const updateUser = async (userId: number, updateData: UpdateUser) => {
   const user = await userRepository.findById(userId);
-  const isPasswordCorrect = await bcrypt.compare(
-    updateData.currentPassword!,
-    user!.password!
-  );
 
-  if (updateData.newPassword && updateData.currentPassword) {
+  if (updateData.newPassword || updateData.currentPassword) {
+    if (!updateData.newPassword || !updateData.currentPassword) {
+      const error: CustomError = new Error("Bad Request");
+      error.status = 400;
+      error.data = {
+        message:
+          "비밀번호 변경을 위해서는 현재 비밀번호와 새로운 비밀번호가 모두 필요합니다.",
+      };
+      throw error;
+    }
+
+    const isPasswordCorrect = await bcrypt.compare(
+      updateData.currentPassword,
+      user!.password!
+    );
+
     if (!isPasswordCorrect) {
       const error: CustomError = new Error("Unauthorized");
       error.status = 401;
@@ -58,13 +69,18 @@ const updateUser = async (userId: number, updateData: UpdateUser) => {
     }
   }
 
-  const hashedNewPassword = await bcrypt.hash(updateData.newPassword!, 10);
+  const updateUserData: {
+    name?: string;
+    phoneNumber?: string;
+    password?: string;
+  } = {};
 
-  const updateUserData = {
-    name: updateData.name,
-    phoneNumber: updateData.phoneNumber,
-    password: hashedNewPassword,
-  };
+  if (updateData.name) updateUserData.name = updateData.name;
+  if (updateData.phoneNumber)
+    updateUserData.phoneNumber = updateData.phoneNumber;
+  if (updateData.newPassword) {
+    updateUserData.password = await bcrypt.hash(updateData.newPassword, 10);
+  }
 
   return await userRepository.updateUser(userId, updateUserData);
 };

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -35,7 +35,9 @@ const updateUser = async (userId: number, updateData: UpdateUser) => {
   const user = await userRepository.findById(userId);
 
   if (updateData.newPassword || updateData.currentPassword) {
+    //새로운 비밀번호, 현재 비밀번호가 존재하면 일단 로직 수행
     if (!updateData.newPassword || !updateData.currentPassword) {
+      //그런데 둘 중 하나라도 없으면 에러 발생
       const error: CustomError = new Error("Bad Request");
       error.status = 400;
       error.data = {


### PR DESCRIPTION
1. 기사 프로필 변경 추가
2. 유저 정보 변경 시 비밀번호가 있을 때만 해시 로직 수행하도록 변경
3. 리프레시 토큰 path 적용 - /auth/refresh