### PR TITLE
[안재민] 에러메시지 세분화, 토큰 path설정 제거

### DIFF
--- a/src/config/cookie.config.ts
+++ b/src/config/cookie.config.ts
@@ -5,7 +5,6 @@ const accessTokenOption: CookieOptions = {
   secure: true,
   sameSite: "none",
   maxAge: 1000 * 60 * 60, // 1시간
-  path: "/",
 };
 
 const refreshTokenOption: CookieOptions = {
@@ -13,7 +12,6 @@ const refreshTokenOption: CookieOptions = {
   secure: true,
   sameSite: "none",
   maxAge: 1000 * 60 * 60 * 24 * 7, // 7일
-  path: "/auth/refresh",
 };
 
 const clearCookieOption: CookieOptions = {
@@ -21,7 +19,6 @@ const clearCookieOption: CookieOptions = {
   secure: true,
   sameSite: "none",
   maxAge: 0,
-  path: "/",
 };
 
 const sessionOption: CookieOptions = {

--- a/src/middlewares/passport.ts
+++ b/src/middlewares/passport.ts
@@ -26,8 +26,8 @@ passport.use(
     const token = req.cookies["accessToken"];
 
     if (!token) {
-      const error: CustomError = new Error("Unauthorized");
-      error.status = 401;
+      const error: CustomError = new Error("Token missing");
+      error.status = 403;
       error.data = {
         message: "토큰이 존재하지 않습니다.",
       };
@@ -38,8 +38,8 @@ passport.use(
       const decoded = jwt.verify(token, JWT_SECRET);
       return done(null, decoded); // 토큰이 있고 유효하면 유저 정보 반환
     } catch (err) {
-      const error: CustomError = new Error("Unauthorized");
-      error.status = 401;
+      const error: CustomError = new Error("Invalid token");
+      error.status = 403;
       error.data = {
         message: "유효하지 않은 토큰입니다.",
       };
@@ -71,8 +71,8 @@ passport.use(
     const refreshToken = req.cookies["refreshToken"];
 
     if (!refreshToken) {
-      const error: CustomError = new Error("Unauthorized");
-      error.status = 401;
+      const error: CustomError = new Error("Token missing");
+      error.status = 403;
       error.data = {
         message: "리프레시 토큰이 존재하지 않습니다.",
       };
@@ -83,8 +83,8 @@ passport.use(
       const decoded = jwt.verify(refreshToken, REFRESH_SECRET);
       return done(null, decoded);
     } catch (err) {
-      const error: CustomError = new Error("Unauthorized");
-      error.status = 401;
+      const error: CustomError = new Error("Invalid token");
+      error.status = 403;
       error.data = {
         message: "유효하지 않은 리프레시 토큰입니다.",
       };

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -47,7 +47,7 @@ const signIn = async ({ email, password }: SignInData) => {
   const isPasswordValid = await bcrypt.compare(password, user.password!); //패스워드 검증
 
   if (!isPasswordValid) {
-    const error: CustomError = new Error("Unauthorized");
+    const error: CustomError = new Error("Invalid password");
     error.status = 401;
     error.data = {
       message: "비밀번호가 일치하지 않습니다.",
@@ -181,7 +181,7 @@ const validatePassword = async (userId: number, password: string) => {
   }
 
   if (!decodedPassword) {
-    const error: CustomError = new Error("Unauthorized");
+    const error: CustomError = new Error("Invalid password");
     error.status = 401;
     error.data = {
       message: "비밀번호가 일치하지 않습니다.",

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -53,7 +53,7 @@ const updateUser = async (userId: number, updateData: UpdateUser) => {
     );
 
     if (!isPasswordCorrect) {
-      const error: CustomError = new Error("Unauthorized");
+      const error: CustomError = new Error("Invalid password");
       error.status = 401;
       error.data = {
         message: "현재 비밀번호가 일치하지 않습니다.",


### PR DESCRIPTION
1. 에러메시지 세분화(비밀번호, 토큰)
비밀번호 미일치 : 401, "Invalid password"
토큰이 없을 때 : 403, "Token missing"
토큰이 유효하지않을 때 : 403, "Invalid token"

2. 토큰 path 설정 제거