### PR TITLE
[안재민] 소셜 회원가입 콜백 로직 수정

### DIFF
--- a/src/controllers/oauthController.ts
+++ b/src/controllers/oauthController.ts
@@ -1,7 +1,7 @@
 import { RequestHandler, Router } from "express";
 import passport from "passport";
 import cookieConfig from "../config/cookie.config";
-import createToken from "../utils/token.utils";
+import createToken, { Payload } from "../utils/token.utils";
 import {
   FRONTEND_URL,
   KAKAO_CALLBACK_URL,
@@ -12,12 +12,6 @@ import {
 import CustomError from "../utils/interfaces/customError";
 
 const router = Router();
-
-interface OAuthUser {
-  id: number;
-  customerId?: number | null;
-  moverId?: number | null;
-}
 
 router.get("/naver/customer", (req, res) => {
   const baseURL = "https://nid.naver.com/oauth2.0/authorize";
@@ -97,7 +91,7 @@ const handleOAuthCallback: RequestHandler = (req, res) => {
   if (!req.user) {
     return res.redirect("/login");
   }
-  const user = req.user as OAuthUser;
+  const user = req.user as Payload;
   const userType = req.query.state as string;
 
   const accessToken = createToken(user, "access");
@@ -106,7 +100,7 @@ const handleOAuthCallback: RequestHandler = (req, res) => {
   res.cookie("accessToken", accessToken, cookieConfig.accessTokenOption);
   res.cookie("refreshToken", refreshToken, cookieConfig.refreshTokenOption);
 
-  if (user.customerId || user.moverId) {
+  if (user.customer?.id || user.mover?.id) {
     res.redirect(FRONTEND_URL);
   } else {
     const messages: Record<string, string> = {


### PR DESCRIPTION
### 1. 패스포트에서 전달되는 user 객체의 고객또는 기사의 id가 있을 때 FRONTEND_URL로 리다이렉트
### 2. 없다면 403에러
```
    const error: CustomError = new Error("Forbidden");
    error.status = 403;
    error.data = {
      message: messages[userType] || "프로필을 등록해주세요.",
      redirectUrl: FRONTEND_URL + redirectUrls[userType],
      redirect: true,
    };
```