### PR TITLE
[안재민] 프로필 등록(고객,기사) 응답 쿠키 추가

### DIFF
--- a/src/controllers/customerController.ts
+++ b/src/controllers/customerController.ts
@@ -2,9 +2,10 @@ import customerService from "../services/customerService";
 import { Router } from "express";
 import { asyncHandle } from "../utils/asyncHandler";
 import passport from "passport";
-import { Payload } from "../utils/token.utils";
+import createToken, { Payload } from "../utils/token.utils";
 import upload from "../utils/multer";
 import { uploadFiles, uploadOptionalFiles } from "../middlewares/uploadFile";
+import cookieConfig from "../config/cookie.config";
 
 const router = Router();
 
@@ -22,7 +23,12 @@ router.post(
         regions: JSON.parse(req.body.regions).map(Number),
         services: JSON.parse(req.body.services).map(Number),
       };
-      await customerService.createCustomerProfile(profile);
+      const { id } = await customerService.createCustomerProfile(profile);
+
+      const payload = { id: userId, customer: { id: id } };
+
+      const accessToken = createToken(payload, "access");
+      res.cookie("accessToken", accessToken, cookieConfig.accessTokenOption);
       res.status(204).send();
     } catch (error) {
       next(error);

--- a/src/controllers/moverController.ts
+++ b/src/controllers/moverController.ts
@@ -9,8 +9,9 @@ import {
   optionalJwtAuth,
 } from "../middlewares/authMiddleware";
 import upload from "../utils/multer";
-import { Payload } from "../utils/token.utils";
+import createToken, { Payload } from "../utils/token.utils";
 import { uploadFiles, uploadOptionalFiles } from "../middlewares/uploadFile";
+import cookieConfig from "../config/cookie.config";
 
 interface queryString {
   nextCursorId: string;
@@ -209,7 +210,12 @@ router.post(
         regions: JSON.parse(req.body.regions).map(Number),
         services: JSON.parse(req.body.services).map(Number),
       };
-      await moverService.createMoverProfile(profile);
+      const { id } = await moverService.createMoverProfile(profile);
+
+      const payload = { id: userId, mover: { id: id } };
+
+      const accessToken = createToken(payload, "access");
+      res.cookie("accessToken", accessToken, cookieConfig.accessTokenOption);
       res.status(204).send();
     } catch (error) {
       next(error);

--- a/src/middlewares/uploadFile.ts
+++ b/src/middlewares/uploadFile.ts
@@ -46,7 +46,6 @@ export const uploadFiles = asyncHandle(async (req, res, next) => {
     });
 
     req.fileUrls = await Promise.all(uploadPromises);
-    console.log(req.fileUrls);
     next();
   } catch (e) {
     throwHttpError(500, "이미지 업로드 실패");

--- a/src/services/moverService.ts
+++ b/src/services/moverService.ts
@@ -220,7 +220,6 @@ const updateMoverProfile = async (
   profile: UpdateProfile
 ) => {
   const { imageUrl, ...rest } = profile;
-  console.log(rest);
   try {
     return await imageRepository.updateMoverProfile(
       imageUrl ? imageUrl[0] : undefined,


### PR DESCRIPTION
## 1. 프로필 등록(고객,기사) 응답 쿠키 추가

프로필을 등록하고 새로운 토큰을 발급해주지않으면 예전 토큰이 유효한 시간 동안은 새로 업데이트 된 정보를 받아 올 수 없다고 생각하여 고객, 기사 프로필 등록 컨트롤러에 쿠키를 같이 보내주도록 개선하였습니다.

## 2. 불필요한 console.log 제거
프로필 업데이트, 이미지업로드 부분 console.log 제거하였습니다.